### PR TITLE
fix(jade-garden): inferred type issue

### DIFF
--- a/.changeset/seven-fans-guess.md
+++ b/.changeset/seven-fans-guess.md
@@ -1,0 +1,5 @@
+---
+"jade-garden": patch
+---
+
+Fixes inferred type issue by moving types from `utils.ts` back to `types.ts`.

--- a/packages/core/src/cva.ts
+++ b/packages/core/src/cva.ts
@@ -1,6 +1,6 @@
 import { cx } from "./class-utils";
-import type { ClassValue, CreateOptions } from "./types";
-import { type ClassProp, falsyToString, hasProps, kebabCase, type MetaConfig, type StringToBoolean } from "./utils";
+import type { ClassProp, ClassValue, CreateOptions, MetaConfig, StringToBoolean } from "./types";
+import { falsyToString, hasProps, kebabCase } from "./utils";
 
 /* -----------------------------------------------------------------------------
  * CVA

--- a/packages/core/src/sva.ts
+++ b/packages/core/src/sva.ts
@@ -1,6 +1,6 @@
 import { cx } from "./class-utils";
-import type { ClassValue, CreateOptions } from "./types";
-import { type ClassProp, falsyToString, hasProps, kebabCase, type MetaConfig, type StringToBoolean } from "./utils";
+import type { ClassProp, ClassValue, CreateOptions, MetaConfig, StringToBoolean } from "./types";
+import { falsyToString, hasProps, kebabCase } from "./utils";
 
 /* -----------------------------------------------------------------------------
  * SVA

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,6 +30,20 @@ type Attribute<T> =
 type ClassArray = ClassValue[];
 
 /**
+ * Represents the `class` and `className` props for `cva` and `sva`.
+ * Ensures that only one of `class` or `className` is present.
+ */
+export type ClassProp =
+  | {
+      class?: ClassValue;
+      className?: never;
+    }
+  | {
+      class?: never;
+      className?: ClassValue;
+    };
+
+/**
  * Represents the minimum structure to work with class names.
  * Fully compatible input for `jade-garden/class-utils` functions.
  */
@@ -82,6 +96,45 @@ export type CreateOptions = {
 };
 
 /**
+ * **FOR LIBRARY AUTHORS**
+ *
+ * Add JSDoc and CSS comments to components when generating with `unplugin-jade-garden`.
+ */
+export type MetaConfig = {
+  /**
+   * Adds a `deprecated` tag.
+   *
+   * Adds a description if `deprecated` is a string.
+   *
+   * @see https://jsdoc3.vercel.app/tags/deprecated
+   */
+  deprecated?: boolean | string;
+
+  /**
+   * Adds a `description` tag.
+   *
+   * @see https://jsdoc3.vercel.app/tags/description
+   */
+  description?: string;
+
+  /**
+   * Adds a `name` tag.
+   *
+   * `name` should be the same as `name` in style configuration.
+   *
+   * @see https://jsdoc3.vercel.app/tags/name
+   */
+  name?: string;
+
+  /**
+   * Adds a `see` tag.
+   *
+   * @see https://jsdoc3.vercel.app/tags/see
+   */
+  see?: string;
+};
+
+/**
  * The merge function signature for `createCVA` and `createSVA`.
  * @param {...ClassValue[]} inputs - A variadic number of arguments of type {@link ClassValue}.
  * @returns {string} A single string of merged class names.
@@ -95,6 +148,12 @@ export type MergeFn = (...classes: ClassValue[]) => string;
  * @returns {T extends undefined ? never : T} The type with undefined removed.
  */
 type OmitUndefined<T> = T extends undefined ? never : T;
+
+/**
+ * Converts a string literal "true" or "false" to its boolean type.
+ * @template T - The string literal type, e.g., "true" | "false".
+ */
+export type StringToBoolean<T> = T extends "true" | "false" ? boolean : T;
 
 /**
  * Provides type safety for the `data` prop within the `traits` function.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,5 +1,3 @@
-import type { ClassValue } from "./types";
-
 /* -----------------------------------------------------------------------------
  * Utils
  * -----------------------------------------------------------------------------*/
@@ -53,66 +51,3 @@ export const kebabCase = (str: string): string => {
   );
   return words.map((word) => word.toLowerCase()).join("-");
 };
-
-/* -----------------------------------------------------------------------------
- * Types
- * -----------------------------------------------------------------------------*/
-
-/**
- * Represents the `class` and `className` props for `cva` and `sva`.
- * Ensures that only one of `class` or `className` is present.
- */
-export type ClassProp =
-  | {
-      class?: ClassValue;
-      className?: never;
-    }
-  | {
-      class?: never;
-      className?: ClassValue;
-    };
-
-/**
- * **FOR LIBRARY AUTHORS**
- *
- * Add JSDoc and CSS comments to components when generating with `unplugin-jade-garden`.
- */
-export type MetaConfig = {
-  /**
-   * Adds a `deprecated` tag.
-   *
-   * Adds a description if `deprecated` is a string.
-   *
-   * @see https://jsdoc3.vercel.app/tags/deprecated
-   */
-  deprecated?: boolean | string;
-
-  /**
-   * Adds a `description` tag.
-   *
-   * @see https://jsdoc3.vercel.app/tags/description
-   */
-  description?: string;
-
-  /**
-   * Adds a `name` tag.
-   *
-   * `name` should be the same as `name` in style configuration.
-   *
-   * @see https://jsdoc3.vercel.app/tags/name
-   */
-  name?: string;
-
-  /**
-   * Adds a `see` tag.
-   *
-   * @see https://jsdoc3.vercel.app/tags/see
-   */
-  see?: string;
-};
-
-/**
- * Converts a string literal "true" or "false" to its boolean type.
- * @template T - The string literal type, e.g., "true" | "false".
- */
-export type StringToBoolean<T> = T extends "true" | "false" ? boolean : T;


### PR DESCRIPTION
## 📝 Description

> Add a brief description

Fixes an issue with inferred types after installing:
```
The inferred type of 'cva' cannot be named without a reference to '../../../node_modules/jade-garden/dist/utils'. This is likely not portable. A type annotation is necessary.
```

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Moves the types from `utils.ts` back to `types.ts`.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Patch change to fix issue.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Jade Garden users. -->
No.

## 📝 Additional Information
