### PR TITLE
chore(cli): peer dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "typescript": "catalog:",
       },
       "peerDependencies": {
+        "jade-garden": ">=2.0.0",
         "tailwindcss": ">=4.0.0",
       },
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,6 +69,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
+    "jade-garden": ">=2.0.0",
     "tailwindcss": ">=4.0.0"
   }
 }


### PR DESCRIPTION
## 📝 Description

> Add a brief description

Enforce `jade-garden` peer dependencies when installing with CLI.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Jade Garden users could be installing earlier versions of Jade Garden (v1.x) that is not compatible with the CLI.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

This enforces the current working version with the CLI.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Jade Garden users. -->

Yes, for users attempting to use the CLI with the earlier version of Jade Garden. Path to migrate is to upgrade.

## 📝 Additional Information
